### PR TITLE
fix: resolve Jekyll build errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "bigdecimal"
 gem "jekyll", "~> 4.3"
+gem "logger"
 
 
 group :jekyll_plugins do

--- a/_config.yaml
+++ b/_config.yaml
@@ -66,6 +66,8 @@ autopages:
     enabled: false
   categories:
     enabled: true
+    layouts:
+      - 'cat-archive.html'
   collections:
     enabled: false
   authors:


### PR DESCRIPTION
## Summary

This PR fixes all Jekyll build errors and warnings:

### Issues Fixed

1. **Missing autopage_category.html layout**
   - AutoPages plugin was looking for `_layouts/autopage_category.html` which didn't exist
   - **Solution**: Configured AutoPages to use existing `cat-archive.html` layout (following the same pattern as authors using `author-archive.html`)
   - This reuses existing code and avoids duplication

2. **Logger deprecation warning**
   - Ruby 3.5.0 will remove `logger` from default gems
   - **Solution**: Added `gem "logger"` to Gemfile to silence the warning

### Changes

- `_config.yaml`: Added `layouts: ['cat-archive.html']` under `autopages.categories`
- `Gemfile`: Added `gem "logger"`

### Verification

✅ Build completes without errors, warnings, or deprecations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated layout for category archive pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->