### PR TITLE
fix: HTML validity: jekyll-auto-thumbnails + layout head

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :jekyll_plugins do
   gem "jektex"
   gem "jekyll-archives", "~>2.2"
   gem "jekyll-auto-authors"
-  gem 'jekyll-auto-thumbnails', "~> 0.3"
+  gem 'jekyll-auto-thumbnails', "~> 2.0"
   gem "jekyll-feed"
   gem 'jekyll-highlight-cards', "~> 1.0"
   gem 'jekyll-loading-lazy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     jekyll-auto-authors (1.0.6)
       jekyll (>= 3.0.0)
       jekyll-paginate-v2 (>= 3.0.0)
-    jekyll-auto-thumbnails (0.3.3)
+    jekyll-auto-thumbnails (2.0.0)
       jekyll (>= 4.0, < 5.0)
       nokogiri (~> 1.15)
     jekyll-feed (0.17.0)
@@ -185,7 +185,7 @@ DEPENDENCIES
   jekyll (~> 4.3)
   jekyll-archives (~> 2.2)
   jekyll-auto-authors
-  jekyll-auto-thumbnails (~> 0.3)
+  jekyll-auto-thumbnails (~> 2.0)
   jekyll-feed
   jekyll-highlight-cards (~> 1.0)
   jekyll-loading-lazy

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,10 +4,8 @@ layout: compress
 
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: "en" }}">
-  <head>
   {%- include head.html -%}
-  </head>
-  <body a="{{ site.theme_config.appearance | default: "auto" }}">
+  <body data-appearance="{{ site.theme_config.appearance | default: "auto" }}">
     {%- if page.reading_progress -%}
     <div class="reading-progress" aria-hidden="true"><span class="reading-progress-fill"></span></div>
     {%- endif -%}


### PR DESCRIPTION
This pull request addresses W3C validation issues for generated pages.

**jekyll-auto-thumbnails:** bump to 2.x so the plugin no longer re-serializes the whole document through the HTML4 path in a way that injects a duplicate `<meta http-equiv="Content-Type">` next to the existing `<meta charset>`.

**Default layout:** Remove the extra `<head>` wrapper around `{%- include head.html -%}`. The no-style-please `head.html` include already opens and closes `<head>`, so the extra wrapper produced nested `<head><head>` once the plugin stopped normalizing the tree on pages without `<img>` tags. 